### PR TITLE
Fix Incorrect SSH Key Selection

### DIFF
--- a/src/vpndeployer/ansible.py
+++ b/src/vpndeployer/ansible.py
@@ -16,14 +16,14 @@ def gen_sshkey(DO_API_TOKEN):
     data_path = playbook_path()
 
     if os.path.isfile(data_path + '/env/ssh_key') is True:
-        return "SSH Key Already Exists"
+        sshkey_id = open(data_path + '/env/ssh_key.id').read()
+        return [int(key) for key in [sshkey_id]]
 
-    runner = ansible_runner.run(private_data_dir=data_path, playbook='local-sshkeygen.yml',
-                                host_pattern='localhost', extravars={"PATH": data_path}, quiet=True)
-    droplets.add_sshkey(DO_API_TOKEN)
+    ansible_runner.run(private_data_dir=data_path, playbook='local-sshkeygen.yml',
+                       host_pattern='localhost', extravars={"PATH": data_path}, quiet=True)
+    sshkey_id = droplets.add_sshkey(DO_API_TOKEN)
 
-    # TODO - Return something proper, the key?
-    return runner.status
+    return [sshkey_id]
 
 
 def deploy_openvpn(ip, email):

--- a/src/vpndeployer/droplets.py
+++ b/src/vpndeployer/droplets.py
@@ -57,7 +57,7 @@ def get_droplet_ip(name, api_token):
     return droplet_ip
 
 
-@tenacity.retry(stop=tenacity.stop_after_attempt(5), wait=tenacity.wait_fixed(20), reraise=True)
+@tenacity.retry(stop=tenacity.stop_after_attempt(5), wait=tenacity.wait_fixed(40), reraise=True)
 def check_droplet_connection(ip):
     # Temporary fix due to deprecation warnings. Awaiting https://github.com/paramiko/paramiko/pull/1379
     warnings.filterwarnings(action='ignore', module='.*paramiko.*')
@@ -74,13 +74,9 @@ def add_sshkey(api_token):
     public_key = open(data_path + '/env/ssh_key.pub').read()
     addkey = digitalocean.SSHKey(
         token=api_token, name='VPN-Deployer', public_key=public_key)
+    addkey.create()
 
-    return addkey.create()
+    with open(data_path + '/env/ssh_key.id', 'w+') as f:
+        f.write(str(addkey.id))
 
-
-def get_sshkey_fingerprint(api_token):
-    manager = digitalocean.Manager(token=api_token)
-    sshkeys = manager.get_all_sshkeys()
-    fingerprint = [str(re.findall('[0-9]* VPN-Deployer', str(sshkeys)))[2:10]]
-
-    return [int(key) for key in fingerprint]
+    return addkey.id

--- a/src/vpndeployer/main.py
+++ b/src/vpndeployer/main.py
@@ -42,8 +42,7 @@ def main():
     if args.name == "VPN":
         args.name = args.name + "-" + str(time.time())
 
-    ansible.gen_sshkey(DO_API_TOKEN)
-    sshkey = droplets.get_sshkey_fingerprint(DO_API_TOKEN)
+    sshkey = ansible.gen_sshkey(DO_API_TOKEN)
 
     print("\nDeploy Started!")
     print("This process typically takes less than 5 minutes.\n")


### PR DESCRIPTION
This resolves issue mentioned in #24 due to multiple keys existing with VPN-Deployer name.

Upon creation of the key and adding it to the DigitalOcean account, the fingerprint ID is passed into a variable and stored in a file for later use, if needed. This allows the deploy to capture the correct key every run.